### PR TITLE
fix check param "samesite"

### DIFF
--- a/framework/web/Session.php
+++ b/framework/web/Session.php
@@ -398,8 +398,8 @@ class Session extends Component implements \IteratorAggregate, \ArrayAccess, \Co
             if (PHP_VERSION_ID >= 70300) {
                 session_set_cookie_params($data);
             } else {
-                if (!empty($data['sameSite'])) {
-                    throw new InvalidConfigException('sameSite cookie is not supported by PHP versions < 7.3.0 (set it to null in this environment)');
+                if (!empty($data['samesite'])) {
+                    throw new InvalidConfigException('samesite cookie is not supported by PHP versions < 7.3.0 (set it to null in this environment)');
                 }
                 session_set_cookie_params($data['lifetime'], $data['path'], $data['domain'], $data['secure'], $data['httponly']);
             }


### PR DESCRIPTION
in the $data variable the parameter "samesite" comes in lower case

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | 
| Fixed issues  | #17843
